### PR TITLE
Improve template handling and add description field

### DIFF
--- a/src/Content/Person.php
+++ b/src/Content/Person.php
@@ -6,6 +6,7 @@ use Contao\BackendTemplate;
 use Contao\ContentElement;
 use Contao\Controller;
 use Contao\FilesModel;
+use Contao\StringUtil;
 
 /**
  * Class Person
@@ -79,6 +80,7 @@ class Person extends ContentElement
         $data ['singleSRC'] = $objFile->path;
         $data ['size'] = $arrSize;
         $data ['alt'] = $person->firstname . ' ' . $person->lastname;
+        $data ['description'] = StringUtil::toHtml5($person->description);
         return $data;
     }
 }

--- a/src/Module/PersonList.php
+++ b/src/Module/PersonList.php
@@ -7,6 +7,7 @@ use Contao\Controller;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
 use Contao\Module;
+use Contao\StringUtil;
 use Mindbird\Contao\Person\Model\Person;
 
 /**
@@ -97,6 +98,7 @@ class PersonList extends Module
         $arrData ['singleSRC'] = $file->path;
         $arrData ['size'] = $size;
         $arrData ['alt'] = $person->firstname . ' ' . $person->lastname;
+        $arrData ['description'] = StringUtil::toHtml5($person->description);
 
         return $arrData;
     }

--- a/src/Module/PersonList.php
+++ b/src/Module/PersonList.php
@@ -68,7 +68,7 @@ class PersonList extends Module
         $html = '';
         if ($person) {
             while ($person->next()) {
-                $template = new FrontendTemplate($this->personTpl);
+                $template = new FrontendTemplate($this->strTemplatePerson);
                 $data = $this->getArrayOfPerson($person, $size);
                 foreach ($data as $name => $value) {
                     $template->$name = $value;

--- a/src/Module/PersonList.php
+++ b/src/Module/PersonList.php
@@ -49,6 +49,10 @@ class PersonList extends Module
             return $template->parse();
         }
 
+        if ($this->customTpl) {
+            $this->strTemplate = $this->customTpl;
+        }
+
         if ($this->personTpl) {
             $this->strTemplatePerson = $this->personTpl;
         }

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -1,5 +1,9 @@
 <?php
 
+$GLOBALS ['TL_DCA'] ['tl_module'] ['onload_callback'][]  = array(
+    'tl_module_person', 'onLoadCallback'
+);
+
 $GLOBALS ['TL_DCA'] ['tl_module'] ['palettes'] ['person_list'] = '{title_legend},name,headline,type;{archiv_legend},person_archiv,imgSize;{template_legend},customTpl,personTpl;{protected_legend:hide},protected;
 {expert_legend:hide},guests,cssID,space';
 
@@ -26,11 +30,6 @@ $GLOBALS ['TL_DCA'] ['tl_module'] ['fields']['personTpl'] = array
     'sql' => "varchar(64) NOT NULL default ''"
 );
 
-$GLOBALS ['TL_DCA'] ['tl_module'] ['fields']['customTpl']['options_callback'] = array
-(
-    'tl_module_person', 'getModuleTemplates'
-);
-
 class tl_module_person extends Backend
 {
     public function getPersonTemplates()
@@ -41,5 +40,17 @@ class tl_module_person extends Backend
     public function getModuleTemplates()
     {
         return $this->getTemplateGroup('mod_personlist');
+    }
+
+    public function onLoadCallback(\Contao\DataContainer $dc)
+    {
+        if ($dc->type !== 'person_list') {
+            return;
+        }
+
+        $GLOBALS ['TL_DCA'] ['tl_module'] ['fields']['customTpl']['options_callback'] = array
+        (
+            'tl_module_person', 'getModuleTemplates'
+        );
     }
 }

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -1,6 +1,6 @@
 <?php
 
-$GLOBALS ['TL_DCA'] ['tl_module'] ['palettes'] ['person_list'] = '{title_legend},name,headline,type;{archiv_legend},person_archiv,imgSize;{template_legend},personTpl;{protected_legend:hide},protected;
+$GLOBALS ['TL_DCA'] ['tl_module'] ['palettes'] ['person_list'] = '{title_legend},name,headline,type;{archiv_legend},person_archiv,imgSize;{template_legend},customTpl,personTpl;{protected_legend:hide},protected;
 {expert_legend:hide},guests,cssID,space';
 
 $GLOBALS ['TL_DCA'] ['tl_module'] ['fields'] ['person_archiv'] = array(
@@ -26,10 +26,20 @@ $GLOBALS ['TL_DCA'] ['tl_module'] ['fields']['personTpl'] = array
     'sql' => "varchar(64) NOT NULL default ''"
 );
 
+$GLOBALS ['TL_DCA'] ['tl_module'] ['fields']['customTpl']['options_callback'] = array
+(
+    'tl_module_person', 'getModuleTemplates'
+);
+
 class tl_module_person extends Backend
 {
     public function getPersonTemplates()
     {
         return $this->getTemplateGroup('person_');
+    }
+
+    public function getModuleTemplates()
+    {
+        return $this->getTemplateGroup('mod_personlist');
     }
 }

--- a/src/Resources/contao/dca/tl_person.php
+++ b/src/Resources/contao/dca/tl_person.php
@@ -74,7 +74,7 @@ $GLOBALS ['TL_DCA'] ['tl_person'] = array(
     ),
     // Palettes
     'palettes' => array(
-        'default' => '{name_legend},firstname, lastname, function; {address_legend}, street, street_number, postal_code, city; {contact_legend}, phone, email; {image_legend}, image;'
+        'default' => '{name_legend},firstname, lastname, function; {address_legend}, street, street_number, postal_code, city; {contact_legend}, phone, email; {image_legend}, image;{description_legend}, description;'
     ),
     // Fields
     'fields' => array(
@@ -206,6 +206,18 @@ $GLOBALS ['TL_DCA'] ['tl_person'] = array(
                 'extensions' => 'jpg, jpeg, png, gif'
             ),
             'sql' => "binary(16) NULL"
+        ),
+        'description' => array(
+            'label' => &$GLOBALS['TL_LANG']['tl_person']['description'],
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'textarea',
+            'eval' => array(
+                'rte' => 'tinyMCE',
+                'helpwizard' => true
+            ),
+            'explanation' => 'insertTags',
+            'sql' => "mediumtext NULL"
         )
     )
 );

--- a/src/Resources/contao/languages/de/tl_person.php
+++ b/src/Resources/contao/languages/de/tl_person.php
@@ -24,6 +24,7 @@ $GLOBALS['TL_LANG']['tl_person']['city'] = array('Ort', 'Bitte tragen Sie den Or
 $GLOBALS['TL_LANG']['tl_person']['phone'] = array('Telefon', 'Bitte tragen Sie die Telefonnummer ein.');
 $GLOBALS['TL_LANG']['tl_person']['email'] = array('E-Mail', 'Bitte tragen Sie die E-Mailadresse ein.');
 $GLOBALS['TL_LANG']['tl_person']['image'] = array('Foto', 'Bitte wählen Sie ein Foto aus.');
+$GLOBALS['TL_LANG']['tl_person']['description'] = array('Beschreibung', 'Bitte geben Sie eine Beschreibung ein.');
 
 
 /**
@@ -33,6 +34,7 @@ $GLOBALS['TL_LANG']['tl_person']['name_legend'] = 'Name';
 $GLOBALS['TL_LANG']['tl_person']['address_legend'] = 'Adresse';
 $GLOBALS['TL_LANG']['tl_person']['contact_legend'] = 'Kontakt';
 $GLOBALS['TL_LANG']['tl_person']['image_legend'] = 'Foto';
+$GLOBALS['TL_LANG']['tl_person']['description_legend'] = 'Beschreibung';
 
 
 /**

--- a/src/Resources/contao/templates/ce_person.html5
+++ b/src/Resources/contao/templates/ce_person.html5
@@ -28,5 +28,8 @@
         <?php if ($this->email) { ?>
             <p class="email" itemprop="email"><?php print $this->email; ?></p>
         <?php } ?>
+        <?php if ($this->description) { ?>
+        <div class="description" itemprop="description"><?php print $this->description; ?></div>
+        <?php } ?>
     </div>
 </div>

--- a/src/Resources/contao/templates/person_list.html5
+++ b/src/Resources/contao/templates/person_list.html5
@@ -28,4 +28,7 @@
     <?php if ($this->email) { ?>
     <p class="email" itemprop="email"><?php print $this->email; ?></p>
     <?php } ?>
+    <?php if ($this->description) { ?>
+    <div class="description" itemprop="description"><?php print $this->description; ?></div>
+    <?php } ?>
 </div>


### PR DESCRIPTION
This PR targets #6 and #7. You now have a field to store a persons description and output it in the default template. We also fixed and issue with the default template selection and added the possibility to select a custom module template for person list module. 

We had to implement a custom options callback rather than using the core method, as there is a little deviation of the registred module type "person_list" and the template naming ("mod_personlist" rather than "mod_person_list"). We did not want to break backwards compatibility, hence the new callback :)